### PR TITLE
strip trailing # from uri when removing the hash

### DIFF
--- a/lib/adal.js
+++ b/lib/adal.js
@@ -1118,6 +1118,11 @@ var AuthenticationContext = (function () {
             }
             if (!this.popUp) {
                 window.location.hash = '';
+                if(window.history){
+                    var uri = window.location.href;
+                    var uriNoHash = uri.substring(0, uri.indexOf('#'));
+                    window.history.replaceState({}, document.title, uriNoHash);
+                }
                 if (this.config.navigateToLoginRequestUrl)
                     window.location.href = this._getItem(this.CONSTANTS.STORAGE.LOGIN_REQUEST);
             }


### PR DESCRIPTION
In a non-angular site, `handleWindowCallback` only removes `window.location.hash`, but not the trailing `#`.   I see in the dev branch, there has been a change made which seems to work when `navigateToLoginRequestUrl` is enabled, but introduces an unnecessary full page load. This is less than ideal for a single page app. Instead, if the browser supports history, just use replaceState() to avoid the full page reload.

Instead, it would be ideal to to use `window.history.replaceState()` if it is available.